### PR TITLE
Use separate exports for ES and CommonJS modules

### DIFF
--- a/dist/wrapper.mjs
+++ b/dist/wrapper.mjs
@@ -1,0 +1,3 @@
+import cjsModule from './wavefile.js';
+
+export const WaveFile = cjsModule.WaveFile;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "main": "./dist/wavefile.js",
   "module": "./index.js",
+  "exports": {
+    "import": "./dist/wrapper.mjs",
+    "require": "./dist/wavefile.js"
+  },
   "types": "./index.d.ts",
   "bin": "./bin/wavefile.js",
   "engines": {


### PR DESCRIPTION
Following the approach recommended in the Node.js documentation:

https://nodejs.org/api/packages.html#approach-1-use-an-es-module-wrapper

## Reason for change

Currently if you import the `'prx-wavefile'` package from an ES module in Node, Node will use the CommonJS module in `dist/wavefile.js` and treat the object exported there as the default export.
This means that in order to get the `WaveFile` class, you will need to do:
```
import waveFileModule from 'prx-wavefile';
const { WaveFile } = waveFileModule;
```
rather than the expected pattern of:
```
import { WaveFile } from 'prx-wavefile';
```
The change in this PR re-exports `WaveFile` in a ESM wrapper module.

