### PR TITLE
Add Typescript types for fmt and data chunks

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ declare module wavefile {
      * 'RIFF', 'RIFX' and 'RF64' are supported.
      * @type {string}
      */
-    container: string;
+    container: 'RIFF' | 'RIFX' | 'RF64';
     /**
      * @type {number}
      */
@@ -27,12 +27,12 @@ declare module wavefile {
      * Always 'WAVE'.
      * @type {string}
      */
-    format: string;
+    format: 'WAVE';
     /**
      * The data of the 'fmt' chunk.
      * @type {!Object<string, *>}
      */
-    fmt: object;
+    fmt: WaveFileFmtChunk;
     /**
      * The data of the 'fact' chunk.
      * @type {!Object<string, *>}
@@ -78,7 +78,7 @@ declare module wavefile {
      * The data of the 'data' chunk.
      * @type {!Object<string, *>}
      */
-    data: object;
+    data: WaveFileDataChunk;
     /**
      * The data of the 'LIST' chunks.
      * Each item in this list look like this:
@@ -390,4 +390,43 @@ declare module wavefile {
      */
     get_PMX(): string;
   }
+
+  type WaveFileDataChunk = {
+    /** @type {string} */
+    chunkId: 'data';
+    /** @type {number} */
+    chunkSize: number;
+    /** @type {!Uint8Array} */
+    samples: Uint8Array;
+  };
+
+  type WaveFileFmtChunk = {
+    /** @type {string} */
+    chunkId: 'fmt ';
+    /** @type {number} */
+    chunkSize: number;
+    /** @type {number} */
+    audioFormat: number;
+    /** @type {number} */
+    numChannels: number;
+    /** @type {number} */
+    sampleRate: number;
+    /** @type {number} */
+    byteRate: number;
+    /** @type {number} */
+    blockAlign: number;
+    /** @type {number} */
+    bitsPerSample: number;
+    /** @type {number} */
+    cbSize: number;
+    /** @type {number} */
+    validBitsPerSample: number;
+    /** @type {number} */
+    dwChannelMask: number;
+    /**
+     * 4 32-bit values representing a 128-bit ID
+     * @type {!Array<number>} 
+     */
+    subformat: readonly [number,number,number,number];
+  };
 }


### PR DESCRIPTION
The "fmt " chunk especially is useful to have typings for, e.g. in order to get the sample rate of the wavefile.