### PR TITLE
Typedef fixes

### DIFF
--- a/dist/wrapper.mjs
+++ b/dist/wrapper.mjs
@@ -1,3 +1,4 @@
 import cjsModule from './wavefile.js';
 
 export const WaveFile = cjsModule.WaveFile;
+export default cjsModule;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,36 +1,25 @@
 // Type definitions for wavefile 11.0
-// Project: https://github.com/rochars/wavefile
+// Project: https://github.com/PRX/prx-wavefile
 // Definitions by: Rafael da Silva Rocha <https://github.com/rochars>
-// Definitions: https://github.com/rochars/wavefile
 
-export = wavefile;
-
-declare namespace wavefile {
-  class WaveFile {
+export class WaveFile {
     /**
      * The bit depth code according to the samples.
-     * @type {string}
      */
     bitDepth: string;
     /**
      * The container identifier.
      * 'RIFF', 'RIFX' and 'RF64' are supported.
-     * @type {string}
      */
     container: 'RIFF' | 'RIFX' | 'RF64';
-    /**
-     * @type {number}
-     */
     chunkSize: number;
     /**
      * The format.
      * Always 'WAVE'.
-     * @type {string}
      */
     format: 'WAVE';
     /**
      * The data of the 'fmt' chunk.
-     * @type {!Object<string, *>}
      */
     fmt: WaveFileFmtChunk;
     /**
@@ -68,40 +57,28 @@ declare namespace wavefile {
     ds64: WaveFileDs64Chunk;
     /**
      * The data of the 'data' chunk.
-     * @type {!Object<string, *>}
      */
     data: WaveFileDataChunk;
     /**
      * The data of the 'LIST' chunks.
-     * Each item in this list look like this:
-     *  {
-     *    chunkId: '',
-     *    chunkSize: 0,
-     *    format: '',
-     *    subChunks: []
-     *   }
-     * @type {!Array<!Object>}
      */
     LIST: WaveFileLISTChunk[];
     /**
      * The data of the 'junk' chunk.
-     * @type {!Object<string, *>}
      */
     junk: WaveFileJunkChunk;
     /**
      * The data of the '_PMX' chunk.
-     * @type {!Object<string, *>}
      */
     _PMX: WaveFilePMXChunk;
     /**
-     * Whether to apply a pad byte or not
-     * Defaults to 'true'
-     * @type {boolean}
+     * Whether to apply a pad byte or not.
+     * Defaults to true.
      */
      padBytes: boolean;
 
     /**
-     * @param {Uint8Array=} [wavBuffer=null] A wave file buffer.
+     * @param wavBuffer A wave file buffer.
      * @throws {Error} If no 'RIFF' chunk is found.
      * @throws {Error} If no 'fmt ' chunk is found.
      * @throws {Error} If no 'data' chunk is found.
@@ -110,25 +87,25 @@ declare namespace wavefile {
 
     /**
      * Return the samples packed in a Float64Array.
-     * @param {boolean=} [interleaved=false] True to return interleaved samples,
+     * @param interleaved True to return interleaved samples,
      *   false to return the samples de-interleaved.
-     * @param {Function=} [OutputObject=Float64Array] The sample container.
-     * @return {!(Array|TypedArray)} the samples.
+     * @param OutputObject The sample container.
+     * @return The samples.
      */
     getSamples(interleaved?: boolean, OutputObject?: Function): Float64Array;
 
     /**
      * Return the sample at a given index.
-     * @param {number} index The sample index.
-     * @return {number} The sample.
+     * @param index The sample index.
+     * @return The sample.
      * @throws {Error} If the sample index is off range.
      */
     getSample(index: number): number;
 
     /**
      * Set the sample at a given index.
-     * @param {number} index The sample index.
-     * @param {number} sample The sample.
+     * @param index The sample index.
+     * @param sample The sample.
      * @throws {Error} If the sample index is off range.
      */
     setSample(index: number, sample: number): void;
@@ -136,14 +113,14 @@ declare namespace wavefile {
     /**
      * Set up the WaveFileCreator object based on the arguments passed.
      * Existing chunks are reset.
-     * @param {number} numChannels The number of channels.
-     * @param {number} sampleRate The sample rate.
+     * @param numChannels The number of channels.
+     * @param sampleRate The sample rate.
      *    Integers like 8000, 44100, 48000, 96000, 192000.
-     * @param {string} bitDepthCode The audio bit depth code.
+     * @param bitDepthCode The audio bit depth code.
      *    One of '4', '8', '8a', '8m', '16', '24', '32', '32f', '64'
      *    or any value between '8' and '32' (like '12').
-     * @param {!(Array|TypedArray)} samples The samples.
-     * @param {Object=} options Optional. Used to force the container
+     * @param samples The samples.
+     * @param options Optional. Used to force the container
      *    as RIFX with {'container': 'RIFX'}
      * @throws {Error} If any argument does not meet the criteria.
      */
@@ -161,16 +138,16 @@ declare namespace wavefile {
 
     /**
      * Set up the WaveFileCreator object from an mpeg buffer and/or optional info.
-     * @param {!Uint8Array} mpegBuffer The buffer.
-     * @param {Object=} info Optional Mpeg info such as version, layer,  etc.
+     * @param mpegBuffer The buffer.
+     * @param info Optional Mpeg info such as version, layer, etc.
      * @throws {Error} If the mpeg file cannot be parsed
      */
     fromMpeg(mpegBuffer: Uint8Array, info?: object): void;
 
     /**
      * Set up the WaveFileParser object from a byte buffer.
-     * @param {!Uint8Array} wavBuffer The buffer.
-     * @param {boolean=} [samples=true] True if the samples should be loaded.
+     * @param bytes The buffer.
+     * @param samples True if the samples should be loaded.
      * @throws {Error} If container is not RIFF, RIFX or RF64.
      * @throws {Error} If format is not WAVE.
      * @throws {Error} If no 'fmt ' chunk is found.
@@ -181,7 +158,7 @@ declare namespace wavefile {
     /**
      * Return a byte buffer representig the WaveFileParser object as a .wav file.
      * The return value of this method can be written straight to disk.
-     * @return {!Uint8Array} A wav file.
+     * @return A wav file.
      * @throws {Error} If bit depth is invalid.
      * @throws {Error} If the number of channels is invalid.
      * @throws {Error} If the sample rate is invalid.
@@ -190,14 +167,14 @@ declare namespace wavefile {
 
     /**
      * Use a .wav file encoded as a base64 string to load the WaveFile object.
-     * @param {string} base64String A .wav file as a base64 string.
+     * @param base64String A .wav file as a base64 string.
      * @throws {Error} If any property of the object appears invalid.
      */
     fromBase64(base64String: string): void;
 
     /**
      * Return a base64 string representig the WaveFile object as a .wav file.
-     * @return {string} A .wav file as a base64 string.
+     * @return A .wav file as a base64 string.
      * @throws {Error} If any property of the object appears invalid.
      */
     toBase64(): string;
@@ -205,14 +182,14 @@ declare namespace wavefile {
     /**
      * Return a DataURI string representig the WaveFile object as a .wav file.
      * The return of this method can be used to load the audio in browsers.
-     * @return {string} A .wav file as a DataURI.
+     * @return A .wav file as a DataURI.
      * @throws {Error} If any property of the object appears invalid.
      */
     toDataURI(): string;
 
     /**
      * Use a .wav file encoded as a DataURI to load the WaveFile object.
-     * @param {string} dataURI A .wav file as DataURI.
+     * @param dataURI A .wav file as DataURI.
      * @throws {Error} If any property of the object appears invalid.
      */
     fromDataURI(dataURI: string): void;
@@ -229,9 +206,9 @@ declare namespace wavefile {
 
     /**
      * Change the bit depth of the samples.
-     * @param {string} newBitDepth The new bit depth of the samples.
+     * @param newBitDepth The new bit depth of the samples.
      *    One of '8' ... '32' (integers), '32f' or '64' (floats)
-     * @param {boolean=} [changeResolution=true] A boolean indicating if the
+     * @param changeResolution A boolean indicating if the
      *    resolution of samples should be actually changed or not.
      * @throws {Error} If the bit depth is not valid.
      */
@@ -239,8 +216,8 @@ declare namespace wavefile {
 
     /**
      * Convert the sample rate of the file.
-     * @param {number} sampleRate The target sample rate.
-     * @param {Object=} options The extra configuration, if needed.
+     * @param sampleRate The target sample rate.
+     * @param options The extra configuration, if needed.
      */
     toSampleRate(sampleRate: number, options?: object): void;
 
@@ -253,7 +230,7 @@ declare namespace wavefile {
 
     /**
      * Decode a 4-bit IMA ADPCM wave file as a 16-bit wave file.
-     * @param {string=} [bitDepthCode='16'] The new bit depth of the samples.
+     * @param bitDepthCode The new bit depth of the samples.
      *  One of '8' ... '32' (integers), '32f' or '64' (floats).
      */
     fromIMAADPCM(bitDepthCode?: string): void;
@@ -265,7 +242,7 @@ declare namespace wavefile {
 
     /**
      * Decode a 8-bit A-Law wave file into a 16-bit wave file.
-     * @param {string=} [bitDepthCode='16'] The new bit depth of the samples.
+     * @param bitDepthCode The new bit depth of the samples.
      *  One of '8' ... '32' (integers), '32f' or '64' (floats).
      */
     fromALaw(bitDepthCode?: string): void;
@@ -277,7 +254,7 @@ declare namespace wavefile {
 
     /**
      * Decode a 8-bit mu-Law wave file into a 16-bit wave file.
-     * @param {string=} [bitDepthCode='16'] The new bit depth of the samples.
+     * @param bitDepthCode The new bit depth of the samples.
      *  One of '8' ... '32' (integers), '32f' or '64' (floats).
      */
     fromMuLaw(bitDepthCode?: string): void;
@@ -285,41 +262,41 @@ declare namespace wavefile {
     /**
      * Write a RIFF tag in the INFO chunk. If the tag do not exist,
      * then it is created. It if exists, it is overwritten.
-     * @param {string} tag The tag name.
-     * @param {string} value The tag value.
+     * @param tag The tag name.
+     * @param value The tag value.
      * @throws {Error} If the tag name is not valid.
      */
     setTag(tag: string, value: string): void;
 
     /**
      * Return the value of a RIFF tag in the INFO chunk.
-     * @param {string} tag The tag name.
-     * @return {?string} The value if the tag is found, null otherwise.
+     * @param tag The tag name.
+     * @return The value if the tag is found, null otherwise.
      */
     getTag(tag: string): string | null;
 
     /**
      * Return a Object<tag, value> with the RIFF tags in the file.
-     * @return {!Object<string, string>} The file tags.
+     * @return The file tags.
      */
     listTags(): Record<string, string>;
 
     /**
      * Remove a RIFF tag in the INFO chunk.
-     * @param {string} tag The tag name.
-     * @return {boolean} True if a tag was deleted.
+     * @param tag The tag name.
+     * @return True if a tag was deleted.
      */
     deleteTag(tag: string): boolean;
 
     /**
      * Create a cue point in the wave file.
-     * @param {!Object<string, *>} pointData The data of the cue point.
+     * @param pointData The data of the cue point.
      */
     setCuePoint(pointData: CuePointInput): void;
 
     /**
      * Remove a cue point from a wave file.
-     * @param {number} index the index of the point. First is 1,
+     * @param index the index of the point. First is 1,
      *  second is 2, and so on.
      */
     deleteCuePoint(index: number): void;
@@ -327,69 +304,50 @@ declare namespace wavefile {
     /**
      * Return an array with all cue points in the file, in the order they appear
      * in the file.
-     * Objects representing cue points/regions look like this:
-     *   {
-     *     position: 500, // the position in milliseconds
-     *     label: 'cue marker 1',
-     *     end: 1500, // the end position in milliseconds
-     *     dwName: 1,
-     *     dwPosition: 0,
-     *     fccChunk: 'data',
-     *     dwChunkStart: 0,
-     *     dwBlockStart: 0,
-     *     dwSampleOffset: 22050, // the position as a sample offset
-     *     dwSampleLength: 3646827, // the region length as a sample count
-     *     dwPurposeID: 544106354,
-     *     dwCountry: 0,
-     *     dwLanguage: 0,
-     *     dwDialect: 0,
-     *     dwCodePage: 0,
-     *   }
-     * @return {!Array<Object>}
      */
     listCuePoints(): CuePointOutput[];
 
     /**
      * Update the label of a cue point.
-     * @param {number} pointIndex The ID of the cue point.
-     * @param {string} label The new text for the label.
+     * @param pointIndex The ID of the cue point.
+     * @param label The new text for the label.
      */
     updateLabel(pointIndex: number, label: string): void;
 
     /**
      * Set the value of the iXML chunk.
-     * @param {string} iXMLValue The value for the iXML chunk.
+     * @param iXMLValue The value for the iXML chunk.
      * @throws {TypeError} If the value is not a string.
      */
     setiXML(iXMLValue: string): void;
 
     /**
      * Return the value of the iXML chunk.
-     * @return {string} The contents of the iXML chunk.
+     * @return The contents of the iXML chunk.
      */
     getiXML(): string;
 
     /**
      * Set the value of the _PMX chunk.
-     * @param {string} _PMXValue The value for the _PMX chunk.
+     * @param _PMXValue The value for the _PMX chunk.
      * @throws {TypeError} If the value is not a string.
      */
     set_PMX(_PMXValue: string): void;
 
     /**
      * Get the value of the _PMX chunk.
-     * @return {string} The contents of the _PMX chunk.
+     * @return The contents of the _PMX chunk.
      */
     get_PMX(): string;
-  }
+}
 
-  type WaveFileDataChunk = {
+export type WaveFileDataChunk = {
     chunkId: string;
     chunkSize: number;
     samples: Uint8Array;
-  };
+};
 
-  type WaveFileFmtChunk = {
+export type WaveFileFmtChunk = {
     chunkId: string;
     chunkSize: number;
     audioFormat: number;
@@ -412,40 +370,40 @@ declare namespace wavefile {
     headFlags: number;
     ptsLow: number;
     ptsHigh: number;
-  };
+};
 
-  type WaveFileFactChunk = {
+export type WaveFileFactChunk = {
     chunkId: string;
     chunkSize: number;
     dwSampleLength: number;
-  };
+};
 
-  type WaveFileCuePoint = {
+export type WaveFileCuePoint = {
     dwName: number;
     dwPosition: number;
     fccChunk: string;
     dwChunkStart: number;
     dwBlockStart: number;
     dwSampleOffset: number;
-  };
+};
 
-  type WaveFileCueChunk = {
+export type WaveFileCueChunk = {
     chunkId: string;
     chunkSize: number;
     dwCuePoints: number;
     points: WaveFileCuePoint[];
-  };
+};
 
-  type WaveFileSmplLoop = {
+export type WaveFileSmplLoop = {
     dwName: number;
     dwType: number;
     dwStart: number;
     dwEnd: number;
     dwFraction: number;
     dwPlayCount: number;
-  };
+};
 
-  type WaveFileSmplChunk = {
+export type WaveFileSmplChunk = {
     chunkId: string;
     chunkSize: number;
     dwManufacturer: number;
@@ -458,9 +416,9 @@ declare namespace wavefile {
     dwNumSampleLoops: number;
     dwSamplerData: number;
     loops: WaveFileSmplLoop[];
-  };
+};
 
-  type WaveFileBextChunk = {
+export type WaveFileBextChunk = {
     chunkId: string;
     chunkSize: number;
     description: string;
@@ -479,9 +437,9 @@ declare namespace wavefile {
     maxShortTermLoudness: number;
     reserved: string;
     codingHistory: string;
-  };
+};
 
-  type WaveFileMextChunk = {
+export type WaveFileMextChunk = {
     chunkId: string;
     chunkSize: number;
     soundInformation: number;
@@ -489,14 +447,14 @@ declare namespace wavefile {
     ancillaryDataLength: number;
     ancillaryDataDef: number;
     reserved: string;
-  };
+};
 
-  type WaveFileCartPostTimer = {
+export type WaveFileCartPostTimer = {
     usage: string;
     value: number;
-  };
+};
 
-  type WaveFileCartChunk = {
+export type WaveFileCartChunk = {
     chunkId: string;
     chunkSize: number;
     version: string;
@@ -519,15 +477,15 @@ declare namespace wavefile {
     reserved: string;
     url: string;
     tagText: string;
-  };
+};
 
-  type WaveFileIXMLChunk = {
+export type WaveFileIXMLChunk = {
     chunkId: string;
     chunkSize: number;
     value: string;
-  };
+};
 
-  type WaveFileDs64Chunk = {
+export type WaveFileDs64Chunk = {
     chunkId: string;
     chunkSize: number;
     riffSizeHigh: number;
@@ -537,29 +495,29 @@ declare namespace wavefile {
     originationTime: number;
     sampleCountHigh: number;
     sampleCountLow: number;
-  };
+};
 
-  type WaveFileLISTChunk = {
+export type WaveFileLISTChunk = {
     chunkId: string;
     chunkSize: number;
     format: string;
     subChunks: object[];
-  };
+};
 
-  type WaveFileJunkChunk = {
+export type WaveFileJunkChunk = {
     chunkId: string;
     chunkSize: number;
     chunkData: number[];
-  };
+};
 
-  type WaveFilePMXChunk = {
+export type WaveFilePMXChunk = {
     chunkId: string;
     chunkSize: number;
     value: string;
-  };
+};
 
-  /** Input data for creating a cue point via setCuePoint(). */
-  type CuePointInput = {
+/** Input data for creating a cue point via setCuePoint(). */
+export type CuePointInput = {
     /** The position of the point in milliseconds (required). */
     position: number;
     /** A string label for the cue point. */
@@ -571,10 +529,10 @@ declare namespace wavefile {
     dwLanguage?: number;
     dwDialect?: number;
     dwCodePage?: number;
-  };
+};
 
-  /** Output data returned by listCuePoints(). */
-  type CuePointOutput = {
+/** Output data returned by listCuePoints(). */
+export type CuePointOutput = {
     /** The position in milliseconds. */
     position: number;
     /** The label text. */
@@ -595,5 +553,4 @@ declare namespace wavefile {
     dwLanguage: number;
     dwDialect: number;
     dwCodePage: number;
-  };
-}
+};

--- a/index.d.ts
+++ b/index.d.ts
@@ -302,7 +302,7 @@ declare namespace wavefile {
      * Return a Object<tag, value> with the RIFF tags in the file.
      * @return {!Object<string, string>} The file tags.
      */
-    listTags(): object;
+    listTags(): Record<string, string>;
 
     /**
      * Remove a RIFF tag in the INFO chunk.
@@ -315,7 +315,7 @@ declare namespace wavefile {
      * Create a cue point in the wave file.
      * @param {!Object<string, *>} pointData The data of the cue point.
      */
-    setCuePoint(pointData: object): void;
+    setCuePoint(pointData: CuePointInput): void;
 
     /**
      * Remove a cue point from a wave file.
@@ -347,7 +347,7 @@ declare namespace wavefile {
      *   }
      * @return {!Array<Object>}
      */
-    listCuePoints(): Array<object>;
+    listCuePoints(): CuePointOutput[];
 
     /**
      * Update the label of a cue point.
@@ -556,5 +556,44 @@ declare namespace wavefile {
     chunkId: string;
     chunkSize: number;
     value: string;
+  };
+
+  /** Input data for creating a cue point via setCuePoint(). */
+  type CuePointInput = {
+    /** The position of the point in milliseconds (required). */
+    position: number;
+    /** A string label for the cue point. */
+    label?: string;
+    /** End position in milliseconds for regions. */
+    end?: number;
+    dwPurposeID?: number;
+    dwCountry?: number;
+    dwLanguage?: number;
+    dwDialect?: number;
+    dwCodePage?: number;
+  };
+
+  /** Output data returned by listCuePoints(). */
+  type CuePointOutput = {
+    /** The position in milliseconds. */
+    position: number;
+    /** The label text. */
+    label: string;
+    /** The end position in milliseconds, or null if not a region. */
+    end: number | null;
+    dwName: number;
+    dwPosition: number;
+    fccChunk: string;
+    dwChunkStart: number;
+    dwBlockStart: number;
+    /** The position as a sample offset. */
+    dwSampleOffset: number;
+    /** The region length as a sample count, 0 if not a region. */
+    dwSampleLength: number;
+    dwPurposeID: number;
+    dwCountry: number;
+    dwLanguage: number;
+    dwDialect: number;
+    dwCodePage: number;
   };
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -250,7 +250,7 @@ declare namespace wavefile {
      * @param {number} sampleRate The target sample rate.
      * @param {Object=} options The extra configuration, if needed.
      */
-    toSampleRate(samples: number, options?: object): void;
+    toSampleRate(sampleRate: number, options?: object): void;
 
     /**
      * Encode a 16-bit wave file as 4-bit IMA ADPCM.

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,45 +35,37 @@ declare namespace wavefile {
     fmt: WaveFileFmtChunk;
     /**
      * The data of the 'fact' chunk.
-     * @type {!Object<string, *>}
      */
-    fact: object;
+    fact: WaveFileFactChunk;
     /**
      * The data of the 'cue ' chunk.
-     * @type {!Object<string, *>}
      */
-    cue: object;
+    cue: WaveFileCueChunk;
     /**
      * The data of the 'smpl' chunk.
-     * @type {!Object<string, *>}
      */
-    smpl: object;
+    smpl: WaveFileSmplChunk;
     /**
      * The data of the 'bext' chunk.
-     * @type {!Object<string, *>}
      */
-    bext: object;
+    bext: WaveFileBextChunk;
     /**
      * The data of the 'mext' chunk.
-     * @type {!Object<string, *>}
      */
-    mext: object;
+    mext: WaveFileMextChunk;
     /**
      * The data of the 'cart' chunk.
-     * @type {!Object<string, *>}
      */
-    cart: object;
+    cart: WaveFileCartChunk;
     /**
      * The data of the 'iXML' chunk.
-     * @type {!Object<string, *>}
      */
-    iXML: object;
+    iXML: WaveFileIXMLChunk;
     /**
      * The data of the 'ds64' chunk.
      * Used only with RF64 files.
-     * @type {!Object<string, *>}
      */
-    ds64: object;
+    ds64: WaveFileDs64Chunk;
     /**
      * The data of the 'data' chunk.
      * @type {!Object<string, *>}
@@ -90,17 +82,17 @@ declare namespace wavefile {
      *   }
      * @type {!Array<!Object>}
      */
-    LIST: object[];
+    LIST: WaveFileLISTChunk[];
     /**
      * The data of the 'junk' chunk.
      * @type {!Object<string, *>}
      */
-    junk: object;
+    junk: WaveFileJunkChunk;
     /**
      * The data of the '_PMX' chunk.
      * @type {!Object<string, *>}
      */
-    _PMX: object;
+    _PMX: WaveFilePMXChunk;
     /**
      * Whether to apply a pad byte or not
      * Defaults to 'true'
@@ -392,41 +384,177 @@ declare namespace wavefile {
   }
 
   type WaveFileDataChunk = {
-    /** @type {string} */
-    chunkId: 'data';
-    /** @type {number} */
+    chunkId: string;
     chunkSize: number;
-    /** @type {!Uint8Array} */
     samples: Uint8Array;
   };
 
   type WaveFileFmtChunk = {
-    /** @type {string} */
-    chunkId: 'fmt ';
-    /** @type {number} */
+    chunkId: string;
     chunkSize: number;
-    /** @type {number} */
     audioFormat: number;
-    /** @type {number} */
     numChannels: number;
-    /** @type {number} */
     sampleRate: number;
-    /** @type {number} */
     byteRate: number;
-    /** @type {number} */
     blockAlign: number;
-    /** @type {number} */
     bitsPerSample: number;
-    /** @type {number} */
     cbSize: number;
-    /** @type {number} */
     validBitsPerSample: number;
-    /** @type {number} */
     dwChannelMask: number;
-    /**
-     * 4 32-bit values representing a 128-bit ID
-     * @type {!Array<number>} 
-     */
-    subformat: readonly [number,number,number,number];
+    /** 4 32-bit values representing a 128-bit ID */
+    subformat: number[];
+    /** MPEG fields (present when audioFormat == 80) */
+    headLayer: number;
+    headBitRate: number;
+    headMode: number;
+    headModeExt: number;
+    headEmphasis: number;
+    headFlags: number;
+    ptsLow: number;
+    ptsHigh: number;
+  };
+
+  type WaveFileFactChunk = {
+    chunkId: string;
+    chunkSize: number;
+    dwSampleLength: number;
+  };
+
+  type WaveFileCuePoint = {
+    dwName: number;
+    dwPosition: number;
+    fccChunk: string;
+    dwChunkStart: number;
+    dwBlockStart: number;
+    dwSampleOffset: number;
+  };
+
+  type WaveFileCueChunk = {
+    chunkId: string;
+    chunkSize: number;
+    dwCuePoints: number;
+    points: WaveFileCuePoint[];
+  };
+
+  type WaveFileSmplLoop = {
+    dwName: number;
+    dwType: number;
+    dwStart: number;
+    dwEnd: number;
+    dwFraction: number;
+    dwPlayCount: number;
+  };
+
+  type WaveFileSmplChunk = {
+    chunkId: string;
+    chunkSize: number;
+    dwManufacturer: number;
+    dwProduct: number;
+    dwSamplePeriod: number;
+    dwMIDIUnityNote: number;
+    dwMIDIPitchFraction: number;
+    dwSMPTEFormat: number;
+    dwSMPTEOffset: number;
+    dwNumSampleLoops: number;
+    dwSamplerData: number;
+    loops: WaveFileSmplLoop[];
+  };
+
+  type WaveFileBextChunk = {
+    chunkId: string;
+    chunkSize: number;
+    description: string;
+    originator: string;
+    originatorReference: string;
+    originationDate: string;
+    originationTime: string;
+    /** 2 32-bit values, timeReference high and low */
+    timeReference: [number, number];
+    version: number;
+    UMID: string;
+    loudnessValue: number;
+    loudnessRange: number;
+    maxTruePeakLevel: number;
+    maxMomentaryLoudness: number;
+    maxShortTermLoudness: number;
+    reserved: string;
+    codingHistory: string;
+  };
+
+  type WaveFileMextChunk = {
+    chunkId: string;
+    chunkSize: number;
+    soundInformation: number;
+    frameSize: number;
+    ancillaryDataLength: number;
+    ancillaryDataDef: number;
+    reserved: string;
+  };
+
+  type WaveFileCartPostTimer = {
+    usage: string;
+    value: number;
+  };
+
+  type WaveFileCartChunk = {
+    chunkId: string;
+    chunkSize: number;
+    version: string;
+    title: string;
+    artist: string;
+    cutId: string;
+    clientId: string;
+    category: string;
+    classification: string;
+    outCue: string;
+    startDate: string;
+    startTime: string;
+    endDate: string;
+    endTime: string;
+    producerAppId: string;
+    producerAppVersion: string;
+    userDef: string;
+    levelReference: number;
+    postTimer: WaveFileCartPostTimer[];
+    reserved: string;
+    url: string;
+    tagText: string;
+  };
+
+  type WaveFileIXMLChunk = {
+    chunkId: string;
+    chunkSize: number;
+    value: string;
+  };
+
+  type WaveFileDs64Chunk = {
+    chunkId: string;
+    chunkSize: number;
+    riffSizeHigh: number;
+    riffSizeLow: number;
+    dataSizeHigh: number;
+    dataSizeLow: number;
+    originationTime: number;
+    sampleCountHigh: number;
+    sampleCountLow: number;
+  };
+
+  type WaveFileLISTChunk = {
+    chunkId: string;
+    chunkSize: number;
+    format: string;
+    subChunks: object[];
+  };
+
+  type WaveFileJunkChunk = {
+    chunkId: string;
+    chunkSize: number;
+    chunkData: number[];
+  };
+
+  type WaveFilePMXChunk = {
+    chunkId: string;
+    chunkSize: number;
+    value: string;
   };
 }


### PR DESCRIPTION
I saw some other PRs for typedefs that weren't right and the typedefs for cart chunk and related other chunks were pretty vague, so this fixes those issues, and the export style - this obviously builds off PR #14 :

Bug:
- toSampleRate(samples: number, ...) — parameter should be sampleRate, not samples

Chunk types are all object — these should have proper interfaces:
- fact — has chunkId, chunkSize, dwSampleLength
- cue — has chunkId, chunkSize, dwCuePoints, points (array of point objects)
- smpl — has 12 fields plus loops array (each with 6 fields)
- bext — has 17 fields (BWF metadata)
- mext — has 7 fields (MPEG extension)
- cart — has 22 fields including postTimer array
- iXML, _PMX — have chunkId, chunkSize, value
- ds64 — has 9 fields (RF64 size info)
- junk — has chunkId, chunkSize, chunkData

Missing from fmt type:
- MPEG fields (headLayer, headBitRate, headMode, headModeExt, headEmphasis, headFlags, ptsLow, ptsHigh) — should be optional

Return types too vague:
- listTags() returns object — should be Record<string, string>
- listCuePoints() returns Array<object> — should have a CuePoint interface with all 15 fields

Missing method:
- getLISTIndex(listType: string): number | null — public method on WaveFileTagEditor

Export style:
- Uses export = wavefile / declare namespace (CJS-style). Now that the package has "type": "module" and ESM exports, this should use export class WaveFile instead.